### PR TITLE
Fix ANSI colors and improve debug output

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,17 +1,18 @@
 use std::env;
 
 // ANSI color and formatting codes - match bash script exactly
-pub const RED: &str = "\033[0;31m";
-pub const GREEN: &str = "\033[0;32m";
-pub const YELLOW: &str = "\033[1;33m";
-pub const BLUE: &str = "\033[0;34m";
-pub const PURPLE: &str = "\033[0;35m";
-pub const CYAN: &str = "\033[0;36m";
-pub const WHITE: &str = "\033[1;37m";
-pub const GRAY: &str = "\033[0;37m";  // Use same gray as bash script
-pub const DEFAULT: &str = "\033[39m"; // Default foreground color
-pub const RESET: &str = "\033[0m";
-pub const BOLD: &str = "\033[1m";
+// Use explicit escape character (\x1b) so the terminal interprets colors properly
+pub const RED: &str = "\x1b[0;31m";
+pub const GREEN: &str = "\x1b[0;32m";
+pub const YELLOW: &str = "\x1b[1;33m";
+pub const BLUE: &str = "\x1b[0;34m";
+pub const PURPLE: &str = "\x1b[0;35m";
+pub const CYAN: &str = "\x1b[0;36m";
+pub const WHITE: &str = "\x1b[1;37m";
+pub const GRAY: &str = "\x1b[0;37m";  // Use same gray as bash script
+pub const DEFAULT: &str = "\x1b[39m"; // Default foreground color
+pub const RESET: &str = "\x1b[0m";
+pub const BOLD: &str = "\x1b[1m";
 
 /// Check if the terminal supports colors
 pub fn should_use_colors() -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,17 +16,30 @@ pub fn generate_claude_status() -> Result<String, Box<dyn std::error::Error>> {
 
 pub fn debug_output() -> String {
     use colors::*;
-    
-    format!("{}{}{} {}{}{} {} {}{} TEST{} {} {}{} TIME{} {} {}{} LEFT{} {} {}{} SONNET{}",
-        BOLD, "🧠", RESET,
-        GRAY, "[use /context]", RESET,
+
+    format!(
+        "{}{}{} {}{}{} {} {}{} TEST{} {} {}{} TIME{} {} {}{} LEFT{} {} {}{} SONNET{}\n",
+        BOLD,
+        "🧠",
+        RESET,
+        GRAY,
+        "[use /context]",
+        RESET,
         format!("{}{}{}", GRAY, "|", RESET),
-        BLUE, "💬", RESET,
+        BLUE,
+        "💬",
+        RESET,
         format!("{}{}{}", GRAY, "|", RESET),
-        PURPLE, "⏱️", RESET,
+        PURPLE,
+        "⏱️",
+        RESET,
         format!("{}{}{}", GRAY, "|", RESET),
-        RED, "⏰", RESET,
+        RED,
+        "⏰",
+        RESET,
         format!("{}{}{}", GRAY, "|", RESET),
-        CYAN, "🤖", RESET
+        CYAN,
+        "🤖",
+        RESET
     )
 }


### PR DESCRIPTION
## Summary
- use explicit escape sequences for ANSI colors
- add newline and clearer formatting for `--debug` output

## Testing
- `cargo test`
- `./claude.sh --debug`


------
https://chatgpt.com/codex/tasks/task_e_68af5bdefc90832e8369bc2126db565e