### PR TITLE
feat: scaffold clap-based CLI with placeholder commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ path = "src/main.rs"
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 atty = "0.2"
+clap = { version = "4", features = ["derive"] }
+tabled = "0.14"
+serde = { version = "1.0", features = ["derive"] }
 
 [profile.release]
 strip = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,20 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "rs-claude-bar", about = "Track Claude usage", version)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum Commands {
+    /// Show current Claude status
+    Status,
+    /// Force refresh of cached stats
+    Update,
+    /// Show recent usage windows
+    History,
+    /// Display detailed statistics
+    Stats,
+}

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -1,0 +1,3 @@
+pub fn run() {
+    println!("📜 Showing recent windows... (placeholder)");
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,4 @@
+pub mod history;
+pub mod stats;
+pub mod status;
+pub mod update;

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -1,0 +1,22 @@
+use tabled::{Table, Tabled};
+
+#[derive(Tabled)]
+struct StatRow {
+    metric: &'static str,
+    value: &'static str,
+}
+
+pub fn run() {
+    let data = [
+        StatRow {
+            metric: "Total Tokens",
+            value: "0",
+        },
+        StatRow {
+            metric: "Total Cost",
+            value: "$0.00",
+        },
+    ];
+    let table = Table::new(data).to_string();
+    println!("{}", table);
+}

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,0 +1,8 @@
+use rs_claude_bar::{debug_output, generate_claude_status};
+
+pub fn run() {
+    match generate_claude_status() {
+        Ok(status) => println!("{}", status),
+        Err(_) => println!("{}", debug_output()),
+    }
+}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,0 +1,3 @@
+pub fn run() {
+    println!("🔄 Forcing stats update... (placeholder)");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,15 @@
-use rs_claude_bar::{generate_claude_status, debug_output};
-use std::env;
+mod cli;
+mod commands;
+
+use clap::Parser;
+use cli::{Cli, Commands};
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    
-    // Check for debug flag (Rust standard convention)
-    if args.len() > 1 && args[1] == "--debug" {
-        print!("{}", debug_output());
-        return;
-    }
-    
-    match generate_claude_status() {
-        Ok(status) => print!("{}", status),
-        Err(e) => print!("🤖 Claude Code | ❌ Error: {}", e),
+    let cli = Cli::parse();
+    match cli.command.unwrap_or(Commands::Status) {
+        Commands::Status => commands::status::run(),
+        Commands::Update => commands::update::run(),
+        Commands::History => commands::history::run(),
+        Commands::Stats => commands::stats::run(),
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,70 +1,98 @@
-use std::path::Path;
-use std::fs;
+use chrono::{DateTime, Duration, Utc};
+use serde::Deserialize;
 use std::env;
-use serde_json::Value;
-use chrono::{DateTime, Utc, Duration};
+use std::fs;
+use std::path::Path;
 
 use crate::types::{UsageEntry, UsageWindow};
 use crate::utils::format_model_name;
 
+#[derive(Deserialize, Default)]
+struct RawUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+    #[serde(default, rename = "cache_creation_input_tokens")]
+    cache_creation_input_tokens: u32,
+    #[serde(default, rename = "cache_read_input_tokens")]
+    cache_read_input_tokens: u32,
+}
+
+#[derive(Deserialize, Default)]
+struct RawMessage {
+    #[serde(default)]
+    model: String,
+    #[serde(rename = "model_display_name", default)]
+    model_display_name: Option<String>,
+    #[serde(default)]
+    usage: RawUsage,
+}
+
+#[derive(Deserialize, Default)]
+struct RawModel {
+    #[serde(default)]
+    id: String,
+    #[serde(rename = "display_name", default)]
+    display_name: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawEntry {
+    timestamp: String,
+    #[serde(rename = "sessionId", default)]
+    session_id: String,
+    #[serde(default)]
+    message: Option<RawMessage>,
+    #[serde(default)]
+    model: Option<RawModel>,
+    #[serde(rename = "costUSD", default)]
+    cost_usd: f64,
+}
+
 /// Parse a single JSONL line into a UsageEntry
 pub fn parse_jsonl_entry(line: &str) -> Result<UsageEntry, Box<dyn std::error::Error>> {
-    let json: Value = serde_json::from_str(line)
-        .map_err(|e| format!("JSON parse error: {}", e))?;
-    
-    // Extract timestamp
-    let timestamp_str = json["timestamp"]
-        .as_str()
-        .ok_or("Missing timestamp field")?;
-    let timestamp = DateTime::parse_from_rfc3339(timestamp_str)
+    let raw: RawEntry =
+        serde_json::from_str(line).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let timestamp = DateTime::parse_from_rfc3339(&raw.timestamp)
         .map_err(|e| format!("Invalid timestamp format: {}", e))?
         .with_timezone(&Utc);
-    
-    // Extract session ID
-    let session_id = json["sessionId"]
-        .as_str()
-        .unwrap_or("unknown")
-        .to_string();
-    
-    // Extract model information - check if this is an assistant message with model info
-    let model_id = json["message"]["model"]
-        .as_str()
-        .or_else(|| json["model"]["id"].as_str())
-        .unwrap_or("unknown")
-        .to_string();
-    
-    // Generate display name from model ID
-    let model_display_name = if let Some(display) = json["message"]["model_display_name"].as_str()
-        .or_else(|| json["model"]["display_name"].as_str()) {
-        display.to_string()
+
+    let session_id = raw.session_id;
+
+    let message = raw.message.unwrap_or_default();
+    let usage = message.usage;
+    let input_tokens = usage.input_tokens;
+    let output_tokens = usage.output_tokens;
+    let cache_creation_tokens = usage.cache_creation_input_tokens;
+    let cache_read_tokens = usage.cache_read_input_tokens;
+    let total_tokens = input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens;
+    if total_tokens == 0 {
+        return Err("No token usage data (likely user message)".into());
+    }
+
+    let model_id = if !message.model.is_empty() {
+        message.model
     } else {
-        // Generate display name from model ID
-        match model_id.as_str() {
+        raw.model
+            .as_ref()
+            .map(|m| m.id.clone())
+            .unwrap_or_else(|| "unknown".into())
+    };
+
+    let model_display_name = message
+        .model_display_name
+        .or_else(|| raw.model.as_ref().and_then(|m| m.display_name.clone()))
+        .unwrap_or_else(|| match model_id.as_str() {
             id if id.contains("sonnet-4") => "Claude 4 Sonnet".to_string(),
             id if id.contains("sonnet") && id.contains("3.5") => "Claude 3.5 Sonnet".to_string(),
             id if id.contains("sonnet") => "Claude Sonnet".to_string(),
             id if id.contains("opus") => "Claude Opus".to_string(),
             id if id.contains("haiku") => "Claude Haiku".to_string(),
             _ => "Claude".to_string(),
-        }
-    };
-    
-    // Extract usage tokens - only present for assistant messages
-    let usage = &json["message"]["usage"];
-    let input_tokens = usage["input_tokens"].as_u64().unwrap_or(0) as u32;
-    let output_tokens = usage["output_tokens"].as_u64().unwrap_or(0) as u32;
-    let cache_creation_tokens = usage["cache_creation_input_tokens"].as_u64().unwrap_or(0) as u32;
-    let cache_read_tokens = usage["cache_read_input_tokens"].as_u64().unwrap_or(0) as u32;
-    let total_tokens = input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens;
-    
-    // Skip entries with no token usage (usually user messages)
-    if total_tokens == 0 {
-        return Err("No token usage data (likely user message)".into());
-    }
-    
-    // Extract cost - might not be present in all entries
-    let cost_usd = json["costUSD"].as_f64().unwrap_or(0.0);
-    
+        });
+
     Ok(UsageEntry {
         timestamp,
         session_id,
@@ -75,7 +103,7 @@ pub fn parse_jsonl_entry(line: &str) -> Result<UsageEntry, Box<dyn std::error::E
         cache_creation_tokens,
         cache_read_tokens,
         total_tokens,
-        cost_usd,
+        cost_usd: raw.cost_usd,
     })
 }
 
@@ -84,16 +112,16 @@ pub fn load_claude_data() -> Result<Vec<UsageEntry>, Box<dyn std::error::Error>>
     // Find Claude data directory
     let home = env::var("HOME")?;
     let claude_dir = Path::new(&home).join(".claude").join("projects");
-    
+
     if !claude_dir.exists() {
         return Err("No Claude data found".into());
     }
-    
+
     // Parse JSONL files and collect usage data
     let mut all_entries = Vec::new();
     let mut _total_files = 0;
     let mut parse_errors = 0;
-    
+
     if let Ok(entries) = fs::read_dir(&claude_dir) {
         for entry in entries.flatten() {
             if let Ok(project_entries) = fs::read_dir(entry.path()) {
@@ -111,10 +139,14 @@ pub fn load_claude_data() -> Result<Vec<UsageEntry>, Box<dyn std::error::Error>>
                                         parse_errors += 1;
                                         // Only log first few errors to avoid spam
                                         if parse_errors <= 3 {
-                                            eprintln!("Parse error on line {} in {:?}: {}", 
-                                                line_num + 1, file.path(), e);
+                                            eprintln!(
+                                                "Parse error on line {} in {:?}: {}",
+                                                line_num + 1,
+                                                file.path(),
+                                                e
+                                            );
                                         }
-                                    },
+                                    }
                                 }
                             }
                         }
@@ -123,11 +155,11 @@ pub fn load_claude_data() -> Result<Vec<UsageEntry>, Box<dyn std::error::Error>>
             }
         }
     }
-    
+
     if all_entries.is_empty() {
         return Err("No usage data found".into());
     }
-    
+
     Ok(all_entries)
 }
 
@@ -136,18 +168,18 @@ pub fn group_entries_into_windows(entries: Vec<UsageEntry>) -> Vec<UsageWindow> 
     if entries.is_empty() {
         return Vec::new();
     }
-    
+
     // Sort entries by timestamp
     let mut sorted_entries = entries;
     sorted_entries.sort_by_key(|e| e.timestamp);
-    
+
     let mut windows = Vec::new();
     let mut current_window_entries = Vec::new();
     let mut window_start_time: Option<DateTime<Utc>> = None;
-    
+
     for entry in sorted_entries {
         let entry_time = entry.timestamp;
-        
+
         // Determine if this entry belongs to the current window or starts a new one
         let should_start_new_window = match window_start_time {
             None => true, // First entry
@@ -156,28 +188,29 @@ pub fn group_entries_into_windows(entries: Vec<UsageEntry>) -> Vec<UsageWindow> 
                 entry_time > start + Duration::hours(5)
             }
         };
-        
+
         if should_start_new_window {
             // Finish the previous window if it exists
             if !current_window_entries.is_empty() {
-                let window = create_window_from_entries(current_window_entries, window_start_time.unwrap());
+                let window =
+                    create_window_from_entries(current_window_entries, window_start_time.unwrap());
                 windows.push(window);
                 current_window_entries = Vec::new();
             }
-            
+
             // Start new window
             window_start_time = Some(entry_time);
         }
-        
+
         current_window_entries.push(entry);
     }
-    
+
     // Handle the last window
     if !current_window_entries.is_empty() {
         let window = create_window_from_entries(current_window_entries, window_start_time.unwrap());
         windows.push(window);
     }
-    
+
     windows
 }
 
@@ -186,7 +219,7 @@ fn create_window_from_entries(entries: Vec<UsageEntry>, start_time: DateTime<Utc
     let total_tokens: u32 = entries.iter().map(|e| e.total_tokens).sum();
     let total_cost: f64 = entries.iter().map(|e| e.cost_usd).sum();
     let message_count = entries.len();
-    
+
     // Collect unique models used in this window
     let mut models_used = Vec::new();
     for entry in &entries {
@@ -195,11 +228,11 @@ fn create_window_from_entries(entries: Vec<UsageEntry>, start_time: DateTime<Utc
             models_used.push(formatted_model);
         }
     }
-    
+
     let end_time = start_time + Duration::hours(5);
     let now = Utc::now();
     let is_active = now >= start_time && now < end_time;
-    
+
     UsageWindow {
         start_time,
         end_time,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 /// Represents a single usage entry from Claude Code logs
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsageEntry {
     pub timestamp: DateTime<Utc>,
     pub session_id: String,
@@ -16,7 +17,7 @@ pub struct UsageEntry {
 }
 
 /// Represents a 5-hour usage window
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsageWindow {
     pub start_time: DateTime<Utc>,
     pub end_time: DateTime<Utc>,


### PR DESCRIPTION
## Summary
- add clap parser with `status`, `update`, `history`, and `stats` subcommands (status default)
- introduce placeholder command implementations including a table for `stats`
- switch parser to serde structs and derive Serialize/Deserialize for types

## Testing
- `cargo test`
- `cargo run -- stats`


------
https://chatgpt.com/codex/tasks/task_e_68af5fcb9da8832e9e339f52699aebf3