### PR TITLE
Add placeholder tests for CLI commands

### DIFF
--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -1,3 +1,13 @@
 pub fn run() {
     println!("📜 Showing recent windows... (placeholder)");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_does_not_panic() {
+        run();
+    }
+}

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -20,3 +20,13 @@ pub fn run() {
     let table = Table::new(data).to_string();
     println!("{}", table);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_does_not_panic() {
+        run();
+    }
+}

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -6,3 +6,13 @@ pub fn run() {
         Err(_) => println!("{}", debug_output()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_does_not_panic() {
+        run();
+    }
+}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,3 +1,13 @@
 pub fn run() {
     println!("🔄 Forcing stats update... (placeholder)");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_does_not_panic() {
+        run();
+    }
+}


### PR DESCRIPTION
## Summary
- add basic `run_does_not_panic` tests for `history`, `stats`, `status`, and `update` commands
- establish groundwork for future command behavior tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68af62477688832ea91b203e566b4b23