### PR TITLE
feat: add display configuration

### DIFF
--- a/.claude-bar/config.json
+++ b/.claude-bar/config.json
@@ -1,0 +1,10 @@
+{
+  "display": [
+    { "name": "context_window_size", "enabled": true, "format": "progress" },
+    { "name": "context_max_tokens", "enabled": true, "format": "number" },
+    { "name": "current_tokens", "enabled": true, "format": "number/max" },
+    { "name": "max_tokens", "enabled": true, "format": "number" },
+    { "name": "refresh_time", "enabled": true, "format": "relative" },
+    { "name": "session_time", "enabled": true, "format": "relative" }
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ atty = "0.2"
 clap = { version = "4", features = ["derive"] }
 tabled = "0.14"
 serde = { version = "1.0", features = ["derive"] }
+dirs = "5"
 
 [profile.release]
 strip = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,4 +17,7 @@ pub enum Commands {
     History,
     /// Display detailed statistics
     Stats,
+    /// Interactively reset display configuration
+    #[command(name = "display-config")]
+    DisplayConfig,
 }

--- a/src/commands/display_config.rs
+++ b/src/commands/display_config.rs
@@ -1,0 +1,7 @@
+use rs_claude_bar::reset_config_interactive;
+
+pub fn run() {
+    // allow user to reset display configuration interactively
+    let cfg = reset_config_interactive();
+    println!("Saved {} display items", cfg.display.len());
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod history;
 pub mod stats;
 pub mod status;
 pub mod update;
+pub mod display_config;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DisplayItem {
+    pub name: String,
+    pub enabled: bool,
+    pub format: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Config {
+    pub display: Vec<DisplayItem>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            display: vec![
+                DisplayItem {
+                    name: "context_window_size".to_string(),
+                    enabled: true,
+                    format: "progress".to_string(),
+                },
+                DisplayItem {
+                    name: "context_max_tokens".to_string(),
+                    enabled: true,
+                    format: "number".to_string(),
+                },
+                DisplayItem {
+                    name: "current_tokens".to_string(),
+                    enabled: true,
+                    format: "number/max".to_string(),
+                },
+                DisplayItem {
+                    name: "max_tokens".to_string(),
+                    enabled: true,
+                    format: "number".to_string(),
+                },
+                DisplayItem {
+                    name: "refresh_time".to_string(),
+                    enabled: true,
+                    format: "relative".to_string(),
+                },
+                DisplayItem {
+                    name: "session_time".to_string(),
+                    enabled: true,
+                    format: "relative".to_string(),
+                },
+            ],
+        }
+    }
+}
+
+fn config_path() -> PathBuf {
+    let mut path = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    path.push(".claude-bar");
+    path.push("config.json");
+    path
+}
+
+pub fn load_config() -> Config {
+    let path = config_path();
+    if let Ok(contents) = fs::read_to_string(&path) {
+        if let Ok(cfg) = serde_json::from_str::<Config>(&contents) {
+            return cfg;
+        }
+    }
+    let cfg = Config::default();
+    let _ = save_config(&cfg);
+    cfg
+}
+
+pub fn save_config(cfg: &Config) -> std::io::Result<()> {
+    let path = config_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let contents = serde_json::to_string_pretty(cfg).unwrap();
+    fs::write(path, contents)
+}
+
+// display-config
+pub fn reset_config_interactive() -> Config {
+    let mut cfg = Config::default();
+    for item in cfg.display.iter_mut() {
+        print!("Show {}? (y/n) ", item.name);
+        let _ = io::stdout().flush();
+        let mut input = String::new();
+        if io::stdin().read_line(&mut input).is_ok() {
+            item.enabled = input.trim().to_lowercase() != "n";
+        }
+        print!("Format for {} [{}]: ", item.name, item.format);
+        let _ = io::stdout().flush();
+        input.clear();
+        if io::stdin().read_line(&mut input).is_ok() {
+            let trimmed = input.trim();
+            if !trimmed.is_empty() {
+                item.format = trimmed.to_string();
+            }
+        }
+    }
+    let _ = save_config(&cfg);
+    cfg
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,14 @@ pub mod types;
 pub mod parser;
 pub mod status;
 pub mod utils;
+pub mod config;
 
 pub use colors::*;
 pub use types::*;
 pub use parser::*;
 pub use status::*;
 pub use utils::*;
+pub use config::*;
 
 pub fn generate_claude_status() -> Result<String, Box<dyn std::error::Error>> {
     status::generate_status()

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,5 +11,6 @@ fn main() {
         Commands::Update => commands::update::run(),
         Commands::History => commands::history::run(),
         Commands::Stats => commands::stats::run(),
+        Commands::DisplayConfig => commands::display_config::run(),
     }
 }


### PR DESCRIPTION
## Summary
- add default `.claude-bar/config.json` describing display items and formats
- implement configuration module with interactive reset functionality
- expose new `display-config` subcommand to manage display preferences

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68af63a441d4832ea16fc3f5028fd7d0