### PR TITLE
Improve usage block detection algorithm

### DIFF
--- a/src/commands/blocks.rs
+++ b/src/commands/blocks.rs
@@ -1,61 +1,75 @@
+use chrono::{DateTime, Duration, Utc};
+use regex::Regex;
+use rs_claude_bar::{
+    claude_types::TranscriptEntry, claudebar_types::ClaudeBarUsageEntry, colors::*,
+};
 use std::fs;
 use std::path::Path;
-use chrono::{DateTime, Utc, Duration};
-use regex::Regex;
-use rs_claude_bar::{claude_types::TranscriptEntry, claudebar_types::ClaudeBarUsageEntry, colors::*};
 
 #[derive(Debug, Clone)]
 pub struct UsageBlock {
     pub start_time: DateTime<Utc>,
-    pub end_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
     pub entries: Vec<ClaudeBarUsageEntry>,
     pub assistant_count: usize,
     pub limit_reached: bool,
-    pub reset_time: Option<String>, // e.g., "10pm", "11pm"
+    pub reset_time: Option<String>,         // e.g., "10pm", "11pm"
     pub unlock_time: Option<DateTime<Utc>>, // calculated unlock timestamp
+    pub guessed: bool,
 }
 
 pub fn run(config: &rs_claude_bar::ConfigInfo) {
     let base_path = format!("{}/projects", config.claude_data_path);
     let path = Path::new(&base_path);
-    
+
     if !path.exists() {
         eprintln!("Path does not exist: {}", base_path);
         return;
     }
-    
-    println!("{bold}{cyan}📊 5-Hour Usage Blocks Analysis{reset}",
+
+    println!(
+        "{bold}{cyan}📊 5-Hour Usage Blocks Analysis{reset}",
         bold = if should_use_colors() { BOLD } else { "" },
         cyan = if should_use_colors() { CYAN } else { "" },
         reset = if should_use_colors() { RESET } else { "" },
     );
     println!();
-    
+
     // Load all entries
     let mut all_entries = load_all_entries(&base_path);
     if all_entries.is_empty() {
         println!("❌ No usage entries found!");
         return;
     }
-    
+
     // Sort by timestamp (ascending for analysis)
     all_entries.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-    
-    println!("📈 Loaded {} entries from {} to {}", 
-             all_entries.len(),
-             all_entries.first().unwrap().timestamp.format("%Y-%m-%d %H:%M UTC"),
-             all_entries.last().unwrap().timestamp.format("%Y-%m-%d %H:%M UTC"));
+
+    println!(
+        "📈 Loaded {} entries from {} to {}",
+        all_entries.len(),
+        all_entries
+            .first()
+            .unwrap()
+            .timestamp
+            .format("%Y-%m-%d %H:%M UTC"),
+        all_entries
+            .last()
+            .unwrap()
+            .timestamp
+            .format("%Y-%m-%d %H:%M UTC")
+    );
     println!();
-    
-    // Find limit reached messages and build blocks
+
+    // Find usage blocks
     let mut blocks = analyze_usage_blocks(&all_entries);
-    
+
     // Sort blocks by start time descending (most recent first)
     blocks.sort_by(|a, b| b.start_time.cmp(&a.start_time));
-    
+
     println!("🔍 Found {} usage blocks:", blocks.len());
     println!();
-    
+
     // Display blocks
     for (i, block) in blocks.iter().enumerate() {
         let limit_indicator = if block.limit_reached {
@@ -63,25 +77,43 @@ pub fn run(config: &rs_claude_bar::ConfigInfo) {
         } else {
             format!("{green}🟢 ACTIVE{reset}", green = GREEN, reset = RESET)
         };
-        
-        let duration = block.end_time.signed_duration_since(block.start_time);
+        let status = if block.guessed {
+            format!("{} (guess)", limit_indicator)
+        } else {
+            limit_indicator
+        };
+
+        let end_display = block
+            .end_time
+            .map(|t| t.format("%Y-%m-%d %H:%M UTC").to_string())
+            .unwrap_or_else(|| "ongoing".to_string());
+
+        let duration = block
+            .end_time
+            .unwrap_or_else(Utc::now)
+            .signed_duration_since(block.start_time);
         let duration_str = format_duration_hours(duration);
-        
-        println!("Block {}: {} - {}", 
-                 i + 1,
-                 block.start_time.format("%Y-%m-%d %H:%M UTC"),
-                 block.end_time.format("%Y-%m-%d %H:%M UTC"));
-        println!("  Duration: {} | Assistant messages: {} | Status: {}", 
-                 duration_str,
-                 block.assistant_count,
-                 limit_indicator);
-        
+
+        println!(
+            "Block {}: {} - {}",
+            i + 1,
+            block.start_time.format("%Y-%m-%d %H:%M UTC"),
+            end_display
+        );
+        println!(
+            "  Duration: {} | Assistant messages: {} | Status: {}",
+            duration_str, block.assistant_count, status
+        );
+
         // Show reset time and unlock time for limit-reached blocks
         if block.limit_reached {
             if let Some(reset_time) = &block.reset_time {
                 print!("  Reset time: {}", reset_time);
                 if let Some(unlock_time) = &block.unlock_time {
-                    println!(" | Unlocks at: {}", unlock_time.format("%Y-%m-%d %H:%M UTC"));
+                    println!(
+                        " | Unlocks at: {}",
+                        unlock_time.format("%Y-%m-%d %H:%M UTC")
+                    );
                 } else {
                     println!(" | Unlock time: could not calculate");
                 }
@@ -89,7 +121,7 @@ pub fn run(config: &rs_claude_bar::ConfigInfo) {
                 println!("  Reset time: not found in limit message");
             }
         }
-        
+
         println!("  Total entries: {}", block.entries.len());
         println!();
     }
@@ -98,30 +130,33 @@ pub fn run(config: &rs_claude_bar::ConfigInfo) {
 fn load_all_entries(base_path: &str) -> Vec<ClaudeBarUsageEntry> {
     let mut usage_entries = Vec::new();
     let path = Path::new(base_path);
-    
+
     if let Ok(entries) = fs::read_dir(path) {
         for entry in entries.flatten() {
             if entry.path().is_dir() {
                 let folder_name = entry.file_name().to_string_lossy().to_string();
-                
+
                 if let Ok(files) = fs::read_dir(entry.path()) {
                     for file in files.flatten() {
                         if file.path().extension().and_then(|s| s.to_str()) == Some("jsonl") {
                             let file_name = file.file_name().to_string_lossy().to_string();
-                            
+
                             // Get file modification date
-                            let file_date = file.metadata()
+                            let file_date = file
+                                .metadata()
                                 .ok()
                                 .and_then(|meta| meta.modified().ok())
                                 .and_then(|time| DateTime::<Utc>::from(time).into());
-                            
+
                             if let Ok(content) = fs::read_to_string(file.path()) {
                                 for line in content.lines() {
                                     if line.trim().is_empty() {
                                         continue;
                                     }
-                                    
-                                    if let Ok(transcript) = serde_json::from_str::<TranscriptEntry>(line) {
+
+                                    if let Ok(transcript) =
+                                        serde_json::from_str::<TranscriptEntry>(line)
+                                    {
                                         let usage_entry = ClaudeBarUsageEntry::from_transcript(
                                             &transcript,
                                             folder_name.clone(),
@@ -138,95 +173,111 @@ fn load_all_entries(base_path: &str) -> Vec<ClaudeBarUsageEntry> {
             }
         }
     }
-    
+
     usage_entries
 }
 
 fn analyze_usage_blocks(entries: &[ClaudeBarUsageEntry]) -> Vec<UsageBlock> {
+    use rs_claude_bar::claudebar_types::UserRole;
+
+    // Consider only assistant messages
+    let mut assistant_entries: Vec<ClaudeBarUsageEntry> = entries
+        .iter()
+        .filter(|e| matches!(e.role, UserRole::Assistant))
+        .cloned()
+        .collect();
+    assistant_entries.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
     let mut blocks = Vec::new();
     let mut current_block_entries: Vec<ClaudeBarUsageEntry> = Vec::new();
     let mut block_start: Option<DateTime<Utc>> = None;
-    let mut previous_was_user = false;
-    
-    for entry in entries {
-        let is_user = matches!(entry.role, rs_claude_bar::claudebar_types::UserRole::User);
-        let is_assistant = matches!(entry.role, rs_claude_bar::claudebar_types::UserRole::Assistant);
-        
-        // Detect limit: when we see assistant messages after user input and is_limit_reached is true
-        let is_limit_hit = entry.is_limit_reached && is_assistant && previous_was_user;
-        
-        if is_limit_hit {
-            
-            // Add current entry to block before ending it
-            current_block_entries.push(entry.clone());
-            
-            // End current block if we have one
-            if !current_block_entries.is_empty() && block_start.is_some() {
+    let mut last_timestamp: Option<DateTime<Utc>> = None;
+
+    for entry in assistant_entries {
+        let timestamp = entry.timestamp;
+
+        if let (Some(last), Some(start)) = (last_timestamp, block_start) {
+            if timestamp - last > Duration::hours(5) {
                 let assistant_count = current_block_entries
                     .iter()
-                    .filter(|e| matches!(e.role, rs_claude_bar::claudebar_types::UserRole::Assistant))
+                    .filter(|e| !e.is_limit_reached)
                     .count();
-                
-                // Parse reset time from the limit message content
-                let content_text = get_entry_content_text(entry);
-                let reset_time = parse_reset_time(&content_text);
-                let unlock_time = reset_time.as_ref()
-                    .and_then(|rt| calculate_unlock_time(entry.timestamp, rt));
-                
+                let end = start + Duration::hours(5);
                 blocks.push(UsageBlock {
-                    start_time: block_start.unwrap(),
-                    end_time: entry.timestamp,
+                    start_time: start,
+                    end_time: Some(end),
                     entries: current_block_entries.clone(),
                     assistant_count,
-                    limit_reached: true,
-                    reset_time,
-                    unlock_time,
+                    limit_reached: false,
+                    reset_time: None,
+                    unlock_time: None,
+                    guessed: true,
                 });
-                
                 current_block_entries.clear();
+                block_start = None;
             }
-            
-            // Start new block after limit reset (estimate 5 hours later)
-            block_start = Some(entry.timestamp + Duration::hours(5));
-            previous_was_user = false;
+        }
+
+        if entry.is_limit_reached {
+            if block_start.is_none() {
+                last_timestamp = Some(timestamp);
+                continue;
+            }
+
+            current_block_entries.push(entry.clone());
+            let assistant_count = current_block_entries
+                .iter()
+                .filter(|e| !e.is_limit_reached)
+                .count();
+            let start = entry.timestamp - Duration::hours(5);
+            let content_text = get_entry_content_text(&entry);
+            let reset_time = parse_reset_time(&content_text);
+            let unlock_time = reset_time
+                .as_ref()
+                .and_then(|rt| calculate_unlock_time(entry.timestamp, rt));
+
+            blocks.push(UsageBlock {
+                start_time: start,
+                end_time: Some(entry.timestamp),
+                entries: current_block_entries.clone(),
+                assistant_count,
+                limit_reached: true,
+                reset_time,
+                unlock_time,
+                guessed: false,
+            });
+
+            current_block_entries.clear();
+            block_start = None;
+            last_timestamp = None;
             continue;
         }
-        
-        // Start first block if we haven't started yet
+
         if block_start.is_none() {
-            block_start = Some(entry.timestamp);
+            block_start = Some(timestamp);
         }
-        
+
         current_block_entries.push(entry.clone());
-        
-        // Track if this was a user message (ignore assistant messages for this tracking)
-        if is_user {
-            previous_was_user = true;
-        }
-        // Don't reset previous_was_user for consecutive assistant messages
+        last_timestamp = Some(timestamp);
     }
-    
-    // Handle remaining entries as final block
-    if !current_block_entries.is_empty() && block_start.is_some() {
+
+    if let Some(start) = block_start {
         let assistant_count = current_block_entries
             .iter()
-            .filter(|e| matches!(e.role, rs_claude_bar::claudebar_types::UserRole::Assistant))
+            .filter(|e| !e.is_limit_reached)
             .count();
-        
-        // End time is last entry timestamp
-        let end_time = current_block_entries.last().unwrap().timestamp;
-        
         blocks.push(UsageBlock {
-            start_time: block_start.unwrap(),
-            end_time,
+            start_time: start,
+            end_time: None,
             entries: current_block_entries,
             assistant_count,
             limit_reached: false,
             reset_time: None,
             unlock_time: None,
+            guessed: false,
         });
     }
-    
+
     blocks
 }
 
@@ -242,67 +293,74 @@ fn parse_reset_time(content: &str) -> Option<String> {
     if let Some(caps) = re.captures(content) {
         return Some(caps[1].to_lowercase());
     }
-    
+
     // Pattern for "resets at 10pm"
     let re2 = Regex::new(r"(?i)resets?\s+at\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm))").ok()?;
     if let Some(caps) = re2.captures(content) {
         return Some(caps[1].to_lowercase());
     }
-    
+
     // Try alternative patterns like "until 10pm" or "at 10pm"
     let re3 = Regex::new(r"(?i)(?:until|at)\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm))").ok()?;
     if let Some(caps) = re3.captures(content) {
         return Some(caps[1].to_lowercase());
     }
-    
+
     None
 }
 
 /// Calculate unlock time based on limit timestamp and reset time
-fn calculate_unlock_time(limit_timestamp: DateTime<Utc>, reset_time: &str) -> Option<DateTime<Utc>> {
+fn calculate_unlock_time(
+    limit_timestamp: DateTime<Utc>,
+    reset_time: &str,
+) -> Option<DateTime<Utc>> {
     // Parse the reset time (e.g., "10pm", "10:30pm")
     let re = Regex::new(r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)").ok()?;
     let caps = re.captures(reset_time)?;
-    
+
     let hour: u32 = caps[1].parse().ok()?;
     let minute: u32 = caps.get(2).map_or(0, |m| m.as_str().parse().unwrap_or(0));
     let is_pm = caps[3].eq_ignore_ascii_case("pm");
-    
+
     // Convert to 24-hour format
     let hour_24 = match (hour, is_pm) {
-        (12, false) => 0,  // 12am -> 0
-        (12, true) => 12,  // 12pm -> 12
-        (h, false) => h,   // am hours
+        (12, false) => 0,    // 12am -> 0
+        (12, true) => 12,    // 12pm -> 12
+        (h, false) => h,     // am hours
         (h, true) => h + 12, // pm hours
     };
-    
+
     if hour_24 >= 24 || minute >= 60 {
         return None;
     }
-    
+
     // Get the date of the limit timestamp
     let limit_date = limit_timestamp.date_naive();
-    
+
     // Create reset time on the same day
-    let reset_time_same_day = limit_date.and_hms_opt(hour_24, minute, 0)?
-        .and_local_timezone(Utc).single()?;
-    
+    let reset_time_same_day = limit_date
+        .and_hms_opt(hour_24, minute, 0)?
+        .and_local_timezone(Utc)
+        .single()?;
+
     // If the reset time already passed today, it's tomorrow
     let unlock_time = if reset_time_same_day > limit_timestamp {
         reset_time_same_day
     } else {
         // Add one day
-        (limit_date + Duration::days(1)).and_hms_opt(hour_24, minute, 0)?
-            .and_local_timezone(Utc).single()?
+        (limit_date + Duration::days(1))
+            .and_hms_opt(hour_24, minute, 0)?
+            .and_local_timezone(Utc)
+            .single()?
     };
-    
+
     Some(unlock_time)
 }
 
 fn format_duration_hours(duration: Duration) -> String {
     let total_hours = duration.num_hours();
     let minutes = (duration.num_minutes() % 60).abs();
-    
+
     if total_hours == 0 {
         format!("{}m", minutes)
     } else {
@@ -313,9 +371,83 @@ fn format_duration_hours(duration: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
+    use rs_claude_bar::claudebar_types::{FileInfo, TokenUsage, UserRole};
 
     #[test]
     fn run_does_not_panic() {
-        run(Some("nonexistent"));
+        let config = rs_claude_bar::ConfigInfo::default();
+        run(&config);
+    }
+
+    fn make_entry(ts: &str, limit: bool) -> ClaudeBarUsageEntry {
+        ClaudeBarUsageEntry {
+            session_id: String::new(),
+            timestamp: DateTime::parse_from_rfc3339(ts)
+                .unwrap()
+                .with_timezone(&Utc),
+            role: UserRole::Assistant,
+            usage: TokenUsage::default(),
+            content_length: 0,
+            is_limit_reached: limit,
+            content_text: if limit {
+                Some("resets 10pm".into())
+            } else {
+                None
+            },
+            file_info: FileInfo {
+                folder_name: String::new(),
+                file_name: String::new(),
+                file_date: None,
+            },
+        }
+    }
+
+    #[test]
+    fn analyze_blocks_detects_limits_and_gaps() {
+        let entries = vec![
+            make_entry("2024-01-01T09:00:00Z", false),
+            make_entry("2024-01-01T10:00:00Z", false),
+            make_entry("2024-01-01T14:00:00Z", true),
+            make_entry("2024-01-01T20:00:00Z", false),
+            make_entry("2024-01-01T21:00:00Z", false),
+            make_entry("2024-01-02T06:00:00Z", false),
+        ];
+
+        let blocks = analyze_usage_blocks(&entries);
+        assert_eq!(blocks.len(), 3);
+
+        assert_eq!(
+            blocks[0].start_time,
+            Utc.with_ymd_and_hms(2024, 1, 1, 9, 0, 0).unwrap()
+        );
+        assert_eq!(
+            blocks[0].end_time.unwrap(),
+            Utc.with_ymd_and_hms(2024, 1, 1, 14, 0, 0).unwrap()
+        );
+        assert!(blocks[0].limit_reached);
+        assert!(!blocks[0].guessed);
+        assert_eq!(blocks[0].assistant_count, 2);
+
+        assert_eq!(
+            blocks[1].start_time,
+            Utc.with_ymd_and_hms(2024, 1, 1, 20, 0, 0).unwrap()
+        );
+        assert_eq!(
+            blocks[1].end_time.unwrap(),
+            Utc.with_ymd_and_hms(2024, 1, 2, 1, 0, 0).unwrap()
+        );
+        assert!(!blocks[1].limit_reached);
+        assert!(blocks[1].guessed);
+        assert_eq!(blocks[1].assistant_count, 2);
+
+        assert_eq!(
+            blocks[2].start_time,
+            Utc.with_ymd_and_hms(2024, 1, 2, 6, 0, 0).unwrap()
+        );
+        assert!(blocks[2].end_time.is_none());
+        assert!(!blocks[2].limit_reached);
+        assert!(!blocks[2].guessed);
+        assert_eq!(blocks[2].assistant_count, 1);
     }
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -1,79 +1,103 @@
+use rs_claude_bar::claude_types::TranscriptEntry;
 use std::fs;
 use std::path::Path;
-use rs_claude_bar::claude_types::TranscriptEntry;
 
 pub fn run(config: &rs_claude_bar::ConfigInfo) {
     let base_path = format!("{}/projects", config.claude_data_path);
     let path = Path::new(&base_path);
-    
+
     if !path.exists() {
         eprintln!("Path does not exist: {}", base_path);
         return;
     }
-    
+
     println!("=== DEBUG: Parsing JSONL files in {} ===", base_path);
-    
+
     if let Ok(entries) = fs::read_dir(path) {
         for entry in entries.flatten() {
             if entry.path().is_dir() {
                 let folder_name = entry.file_name();
                 println!("\n📁 FOLDER: {:?}", folder_name);
-                
+
                 if let Ok(files) = fs::read_dir(entry.path()) {
                     for file in files.flatten() {
                         if file.path().extension().and_then(|s| s.to_str()) == Some("jsonl") {
                             let file_name = file.file_name();
                             println!("  📄 FILE: {:?}", file_name);
-                            
+
                             if let Ok(content) = fs::read_to_string(file.path()) {
                                 for (line_num, line) in content.lines().enumerate() {
                                     if line.trim().is_empty() {
                                         continue;
                                     }
-                                    
+
                                     // Try to parse as TranscriptEntry
                                     match serde_json::from_str::<TranscriptEntry>(line) {
                                         Ok(entry) => {
-                                            println!("    Line {}: ✅ TranscriptEntry", line_num + 1);
+                                            println!(
+                                                "    Line {}: ✅ TranscriptEntry",
+                                                line_num + 1
+                                            );
                                             println!("      -> Full Object: {:#?}", entry);
                                         }
                                         Err(parse_error) => {
                                             // Show detailed parsing error
                                             println!("    Line {}: ❌ Failed to parse as TranscriptEntry", line_num + 1);
                                             println!("      -> Parse Error: {}", parse_error);
-                                            
+
                                             // Try to show what fields are present vs expected
-                                            if let Ok(json_obj) = serde_json::from_str::<serde_json::Value>(line) {
+                                            if let Ok(json_obj) =
+                                                serde_json::from_str::<serde_json::Value>(line)
+                                            {
                                                 if let Some(obj) = json_obj.as_object() {
-                                                    let present_keys: Vec<&String> = obj.keys().collect();
-                                                    println!("      -> Present keys: {:?}", present_keys);
-                                                    
+                                                    let present_keys: Vec<&String> =
+                                                        obj.keys().collect();
+                                                    println!(
+                                                        "      -> Present keys: {:?}",
+                                                        present_keys
+                                                    );
+
                                                     // Check for common expected fields
                                                     let expected_keys = [
-                                                        "parentUuid", "isSidechain", "userType", "cwd",
-                                                        "sessionId", "version", "gitBranch", "type",
-                                                        "uuid", "timestamp", "message"
-                                                        // Optional fields: "isApiErrorMessage", "isMeta", "costUSD"
+                                                        "parentUuid",
+                                                        "isSidechain",
+                                                        "userType",
+                                                        "cwd",
+                                                        "sessionId",
+                                                        "version",
+                                                        "gitBranch",
+                                                        "type",
+                                                        "uuid",
+                                                        "timestamp",
+                                                        "message", // Optional fields: "isApiErrorMessage", "isMeta", "costUSD"
                                                     ];
-                                                    
+
                                                     let missing_keys: Vec<&str> = expected_keys
                                                         .iter()
                                                         .filter(|&&key| !obj.contains_key(key))
                                                         .copied()
                                                         .collect();
-                                                    
+
                                                     if !missing_keys.is_empty() {
-                                                        println!("      -> Missing expected keys: {:?}", missing_keys);
+                                                        println!(
+                                                            "      -> Missing expected keys: {:?}",
+                                                            missing_keys
+                                                        );
                                                     }
-                                                    
+
                                                     let extra_keys: Vec<&String> = present_keys
                                                         .iter()
-                                                        .filter(|key| !expected_keys.contains(&key.as_str()))
+                                                        .filter(|key| {
+                                                            !expected_keys.contains(&key.as_str())
+                                                        })
                                                         .copied()
                                                         .collect();
-                                                    
+
                                                     if !extra_keys.is_empty() {
-                                                        println!("      -> Extra keys: {:?}", extra_keys);
+                                                        println!(
+                                                            "      -> Extra keys: {:?}",
+                                                            extra_keys
+                                                        );
                                                     }
                                                 } else {
                                                     println!("      -> Not a JSON object");
@@ -81,8 +105,10 @@ pub fn run(config: &rs_claude_bar::ConfigInfo) {
                                             } else {
                                                 println!("      -> Invalid JSON");
                                             }
-                                            println!("      -> Line content (first 200 chars): {}", 
-                                                   line.chars().take(200).collect::<String>());
+                                            println!(
+                                                "      -> Line content (first 200 chars): {}",
+                                                line.chars().take(200).collect::<String>()
+                                            );
                                         }
                                     }
                                 }
@@ -105,9 +131,7 @@ mod tests {
 
     #[test]
     fn run_does_not_panic() {
-        let config = rs_claude_bar::ConfigInfo {
-            claude_data_path: "nonexistent".to_string(),
-        };
+        let config = rs_claude_bar::ConfigInfo::default();
         run(&config);
     }
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,7 +1,8 @@
 use rs_claude_bar::colors::*;
 
 pub fn run(_config: &rs_claude_bar::ConfigInfo) {
-    let help_text = format!(r#"
+    let help_text = format!(
+        r#"
 {bold}{cyan}🤖 Claude Bar - Enhanced Claude Code Usage Tracker{reset}
 
 {bold}DESCRIPTION:{reset}
@@ -84,9 +85,7 @@ mod tests {
 
     #[test]
     fn run_does_not_panic() {
-        let config = rs_claude_bar::ConfigInfo {
-            claude_data_path: "nonexistent".to_string(),
-        };
+        let config = rs_claude_bar::ConfigInfo::default();
         run(&config);
     }
 }

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -8,9 +8,7 @@ mod tests {
 
     #[test]
     fn run_does_not_panic() {
-        let config = rs_claude_bar::ConfigInfo {
-            claude_data_path: "nonexistent".to_string(),
-        };
+        let config = rs_claude_bar::ConfigInfo::default();
         run(&config);
     }
 }

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -27,9 +27,7 @@ mod tests {
 
     #[test]
     fn run_does_not_panic() {
-        let config = rs_claude_bar::ConfigInfo {
-            claude_data_path: "nonexistent".to_string(),
-        };
+        let config = rs_claude_bar::ConfigInfo::default();
         run(&config);
     }
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,6 +1,9 @@
 pub fn run(config: &rs_claude_bar::ConfigInfo) {
     // TODO: Implement generate_claude_status_with_config that uses config
-    println!("🔄 Status with config path: {} (placeholder)", config.claude_data_path);
+    println!(
+        "🔄 Status with config path: {} (placeholder)",
+        config.claude_data_path
+    );
 }
 
 #[cfg(test)]
@@ -9,9 +12,7 @@ mod tests {
 
     #[test]
     fn run_does_not_panic() {
-        let config = rs_claude_bar::ConfigInfo {
-            claude_data_path: "nonexistent".to_string(),
-        };
+        let config = rs_claude_bar::ConfigInfo::default();
         run(&config);
     }
 }

--- a/src/commands/table.rs
+++ b/src/commands/table.rs
@@ -1,44 +1,47 @@
+use chrono::{DateTime, Utc};
+use rs_claude_bar::{
+    claude_types::TranscriptEntry,
+    claudebar_types::{group_by_project, ClaudeBarUsageEntry},
+};
 use std::fs;
 use std::path::Path;
 use tabled::{Table, Tabled};
-use chrono::{DateTime, Utc};
-use rs_claude_bar::{claude_types::TranscriptEntry, claudebar_types::{ClaudeBarUsageEntry, group_by_project}};
 
 #[derive(Tabled)]
 struct UsageRow {
     #[tabled(rename = "Session")]
     session_id: String,
-    
+
     #[tabled(rename = "Time")]
     timestamp: String,
-    
+
     #[tabled(rename = "Role")]
     role: String,
-    
+
     #[tabled(rename = "Input")]
     input_tokens: u32,
-    
+
     #[tabled(rename = "Output")]
     output_tokens: u32,
-    
+
     #[tabled(rename = "Cache Create")]
     cache_creation: u32,
-    
+
     #[tabled(rename = "Cache Read")]
     cache_read: u32,
-    
+
     #[tabled(rename = "Total")]
     total_tokens: u32,
-    
+
     #[tabled(rename = "Content Len")]
     content_length: usize,
-    
+
     #[tabled(rename = "Limit Hit")]
     limit_reached: String,
-    
+
     #[tabled(rename = "Folder")]
     folder: String,
-    
+
     #[tabled(rename = "File")]
     file: String,
 }
@@ -46,41 +49,44 @@ struct UsageRow {
 pub fn run(config: &rs_claude_bar::ConfigInfo) {
     let base_path = format!("{}/projects", config.claude_data_path);
     let path = Path::new(&base_path);
-    
+
     if !path.exists() {
         eprintln!("Path does not exist: {}", base_path);
         return;
     }
-    
+
     let mut usage_entries: Vec<ClaudeBarUsageEntry> = Vec::new();
-    
+
     println!("🔍 Processing JSONL files in {}...", base_path);
-    
+
     if let Ok(entries) = fs::read_dir(path) {
         for entry in entries.flatten() {
             if entry.path().is_dir() {
                 let folder_name = entry.file_name().to_string_lossy().to_string();
                 println!("📁 Processing folder: {}", folder_name);
-                
+
                 if let Ok(files) = fs::read_dir(entry.path()) {
                     for file in files.flatten() {
                         if file.path().extension().and_then(|s| s.to_str()) == Some("jsonl") {
                             let file_name = file.file_name().to_string_lossy().to_string();
-                            
+
                             // Get file modification date
-                            let file_date = file.metadata()
+                            let file_date = file
+                                .metadata()
                                 .ok()
                                 .and_then(|meta| meta.modified().ok())
                                 .and_then(|time| DateTime::<Utc>::from(time).into());
-                            
+
                             if let Ok(content) = fs::read_to_string(file.path()) {
                                 for line in content.lines() {
                                     if line.trim().is_empty() {
                                         continue;
                                     }
-                                    
+
                                     // Try to parse as TranscriptEntry
-                                    if let Ok(transcript) = serde_json::from_str::<TranscriptEntry>(line) {
+                                    if let Ok(transcript) =
+                                        serde_json::from_str::<TranscriptEntry>(line)
+                                    {
                                         let usage_entry = ClaudeBarUsageEntry::from_transcript(
                                             &transcript,
                                             folder_name.clone(),
@@ -97,18 +103,18 @@ pub fn run(config: &rs_claude_bar::ConfigInfo) {
             }
         }
     }
-    
+
     if usage_entries.is_empty() {
         println!("❌ No usage entries found!");
         return;
     }
-    
+
     // Sort by timestamp
     usage_entries.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-    
+
     // Project grouping statistics (before moving usage_entries)
     let project_stats = group_by_project(&usage_entries);
-    
+
     // Convert to table rows
     let table_rows: Vec<UsageRow> = usage_entries
         .into_iter()
@@ -127,41 +133,53 @@ pub fn run(config: &rs_claude_bar::ConfigInfo) {
             file: entry.file_info.file_name[..8].to_string(), // Truncate for table
         })
         .collect();
-    
+
     // Get count before moving table_rows
     let entry_count = table_rows.len();
-    
+
     // Display table
     let table = Table::new(&table_rows).to_string();
     println!("\n📊 Claude Bar Usage Table ({} entries):", entry_count);
     println!("{}", table);
-    
+
     // Summary statistics
     let total_tokens: u32 = table_rows.iter().map(|row| row.total_tokens).sum();
-    let limit_hits = table_rows.iter().filter(|row| row.limit_reached == "YES").count();
-    let unique_sessions: std::collections::HashSet<String> = table_rows.iter().map(|row| row.session_id.clone()).collect();
-    
+    let limit_hits = table_rows
+        .iter()
+        .filter(|row| row.limit_reached == "YES")
+        .count();
+    let unique_sessions: std::collections::HashSet<String> = table_rows
+        .iter()
+        .map(|row| row.session_id.clone())
+        .collect();
+
     println!("\n📈 Summary:");
     println!("  Total Entries: {}", table_rows.len());
     println!("  Total Tokens: {}", total_tokens);
     println!("  Limit Hits: {}", limit_hits);
     println!("  Unique Sessions: {}", unique_sessions.len());
-    
+
     println!("\n📊 Project Statistics:");
     for project in &project_stats {
         println!("  Project: {}", project.project_name);
-        println!("    User     - Entries: {}, Tokens: {}, Content: {} chars", 
-                 project.user_stats.entry_count, 
-                 project.user_stats.total_tokens, 
-                 project.user_stats.total_content_length);
-        println!("    Assistant - Entries: {}, Tokens: {}, Content: {} chars", 
-                 project.assistant_stats.entry_count, 
-                 project.assistant_stats.total_tokens, 
-                 project.assistant_stats.total_content_length);
-        println!("    Total    - Entries: {}, Tokens: {}, Content: {} chars", 
-                 project.total_stats.entry_count, 
-                 project.total_stats.total_tokens, 
-                 project.total_stats.total_content_length);
+        println!(
+            "    User     - Entries: {}, Tokens: {}, Content: {} chars",
+            project.user_stats.entry_count,
+            project.user_stats.total_tokens,
+            project.user_stats.total_content_length
+        );
+        println!(
+            "    Assistant - Entries: {}, Tokens: {}, Content: {} chars",
+            project.assistant_stats.entry_count,
+            project.assistant_stats.total_tokens,
+            project.assistant_stats.total_content_length
+        );
+        println!(
+            "    Total    - Entries: {}, Tokens: {}, Content: {} chars",
+            project.total_stats.entry_count,
+            project.total_stats.total_tokens,
+            project.total_stats.total_content_length
+        );
         println!();
     }
 }
@@ -172,6 +190,7 @@ mod tests {
 
     #[test]
     fn run_does_not_panic() {
-        run(Some("nonexistent"));
+        let config = rs_claude_bar::ConfigInfo::default();
+        run(&config);
     }
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -8,9 +8,7 @@ mod tests {
 
     #[test]
     fn run_does_not_panic() {
-        let config = rs_claude_bar::ConfigInfo {
-            claude_data_path: "nonexistent".to_string(),
-        };
+        let config = rs_claude_bar::ConfigInfo::default();
         run(&config);
     }
 }


### PR DESCRIPTION
## Summary
- Only analyze assistant messages when building usage blocks
- Split blocks on 5-hour gaps or explicit limit messages and flag inferred blocks
- Update command tests to construct default config and add unit test for block detection

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68afaa35f494832eabf3bf0cd9cb4ba0