### PR TITLE
Add limit message debug option and show help by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Enhanced Claude Code usage tracker with 5-hour window monitoring, written in Rus
 
 A fast, lightweight alternative to CCUsage for tracking Claude Code token usage, session windows, and providing real-time status information in your Claude Code status bar.
 
+Run `rs-claude-bar` with no arguments to view available commands.
+Use `rs-claude-bar install` to configure Claude settings and `rs-claude-bar prompt` to display the status line.
+
 ## Features
 
 - 🚀 **Fast**: Written in Rust, optimized for performance
@@ -36,10 +39,16 @@ Update your Claude Code settings (`~/.claude/settings.json`):
 {
   "statusLine": {
     "type": "command",
-    "command": "rs-claude-bar",
+    "command": "rs-claude-bar prompt",
     "padding": 0
   }
 }
+```
+
+Or run the built-in installer:
+
+```bash
+rs-claude-bar install
 ```
 
 ## Output Format

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "rs-claude-bar", about = "Track Claude usage", version)]
+#[command(name = "rs-claude-bar", about = "Track Claude usage", version, disable_help_subcommand = true)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -9,6 +9,10 @@ pub struct Cli {
 
 #[derive(Subcommand, Clone)]
 pub enum Commands {
+    /// Show help information
+    Help,
+    /// Show status line prompt
+    Prompt,
     /// Show current Claude status
     Status,
     /// Force refresh of cached stats
@@ -32,9 +36,14 @@ pub enum Commands {
         /// Show only gap analysis (requires --debug)
         #[arg(long, requires = "debug")]
         gaps: bool,
+        /// Show all limit messages with timestamps and file paths (requires --debug)
+        #[arg(long, requires = "debug")]
+        limits: bool,
     },
     /// List only limit messages with [end, end-5h]
     Resets,
+    /// Install command to configure Claude settings
+    Install,
     /// Manage configuration settings
     Config {
         #[command(subcommand)]

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -10,33 +10,45 @@ pub fn run(_config: &rs_claude_bar::ConfigInfo) {
     Parses JSONL transcript files to provide insights into token usage, sessions,
     and 5-hour window limits.
 
+{bold}TIP:{reset}
+    Run `rs-claude-bar install` to configure Claude settings.
+    Use `rs-claude-bar prompt` to print the status line for your shell.
+
 {bold}USAGE:{reset}
     rs-claude-bar [OPTIONS] [COMMAND]
 
 {bold}COMMANDS:{reset}
-    {green}status{reset}           Show current Claude status line (default)
+    {green}help{reset}             Show this help message
+    {green}prompt{reset}           Show current Claude status line
+    {green}status{reset}           Show current Claude status line
     {green}table{reset}            Display usage data in detailed table format
     {green}debug{reset}            Debug parse JSONL files and show raw data
+    {green}install{reset}          Configure Claude settings for prompt
     {green}config{reset}           Manage configuration settings
     {green}stats{reset}            Show statistical summaries
     {green}history{reset}          Show recent usage windows
     {green}update{reset}           Force refresh of cached statistics
     {green}display-config{reset}   Interactively configure display options
-    {green}help{reset}             Show this help message
 
 {bold}OPTIONS:{reset}
     {yellow}-h, --help{reset}             Print help information
     {yellow}-V, --version{reset}          Print version information
 
 {bold}EXAMPLES:{reset}
-    {gray}# Default status line output{reset}
+    {gray}# Show this help message{reset}
     rs-claude-bar
+
+    {gray}# Show status line output{reset}
+    rs-claude-bar prompt
 
     {gray}# Show detailed usage table{reset}
     rs-claude-bar table
 
     {gray}# Debug parsing issues{reset}
     rs-claude-bar debug
+
+    {gray}# Configure Claude settings{reset}
+    rs-claude-bar install
 
     {gray}# Configure Claude data path{reset}
     rs-claude-bar config claude-path

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,0 +1,56 @@
+use rs_claude_bar::ConfigInfo;
+use serde_json::{json, Value};
+use std::fs;
+
+pub fn run(_config: &ConfigInfo) {
+    // Determine settings file path
+    let mut home = match dirs::home_dir() {
+        Some(path) => path,
+        None => {
+            eprintln!("Could not determine home directory");
+            return;
+        }
+    };
+    home.push(".claude");
+
+    let settings_path = home.join("settings.json");
+    let alternate_path = home.join("setting.json");
+
+    // Use existing file if either path exists
+    let path = if settings_path.exists() {
+        settings_path.clone()
+    } else {
+        alternate_path.clone()
+    };
+
+    // Ensure directory exists
+    if let Some(parent) = path.parent() {
+        if let Err(err) = fs::create_dir_all(parent) {
+            eprintln!("Error creating settings directory: {}", err);
+            return;
+        }
+    }
+
+    // Read existing content if file exists
+    let contents = fs::read_to_string(&path).unwrap_or_else(|_| "{}".to_string());
+    let mut data: Value = serde_json::from_str(&contents).unwrap_or_else(|_| json!({}));
+
+    // Ensure statusLine section exists
+    if !data.get("statusLine").is_some() {
+        data["statusLine"] = json!({
+            "type": "command",
+            "command": "rs-claude-bar prompt",
+            "padding": 0
+        });
+    } else if let Some(obj) = data.get_mut("statusLine").and_then(|v| v.as_object_mut()) {
+        obj.insert(
+            "command".to_string(),
+            Value::String("rs-claude-bar prompt".to_string()),
+        );
+    }
+
+    // Write back to file
+    if let Err(err) = fs::write(&path, serde_json::to_string_pretty(&data).unwrap()) {
+        eprintln!("Error writing settings file: {}", err);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,8 @@ pub mod config;
 pub mod debug;
 pub mod help;
 pub mod history;
+pub mod install;
+pub mod prompt;
 pub mod stats;
 pub mod status;
 pub mod table;

--- a/src/commands/prompt.rs
+++ b/src/commands/prompt.rs
@@ -1,0 +1,5 @@
+use rs_claude_bar::ConfigInfo;
+
+pub fn run(config: &ConfigInfo) {
+    super::status::run(config);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ fn main() {
     // Claude input parsing is now handled in the status command itself
 
     // Execute the command
-    match cli.command.unwrap_or(Commands::Status) {
+    match cli.command.unwrap_or(Commands::Help) {
+        Commands::Help => commands::help::run(&config),
+        Commands::Prompt => commands::prompt::run(&config),
         Commands::Status => commands::status::run(&config),
         Commands::Update => commands::update::run(&config),
         Commands::History => commands::history::run(&config),
@@ -22,8 +24,9 @@ fn main() {
         Commands::DisplayConfig => commands::display_config::run(&config),
         Commands::Debug => commands::debug::run(&config),
         Commands::Table => commands::table::run(&config),
-        Commands::Blocks { debug, gaps } => commands::blocks::run(&config, debug, gaps),
+        Commands::Blocks { debug, gaps, limits } => commands::blocks::run(&config, debug, gaps, limits),
         Commands::Resets => commands::resets::run(&config),
+        Commands::Install => commands::install::run(&config),
         Commands::Config { command } => commands::config::run(command, &config),
     }
 }


### PR DESCRIPTION
## Summary
- add `--limits` flag to `blocks` command
- display full limit messages with timestamp and file path in debug mode
- add `prompt` subcommand and `install` command
- show help when no command is provided, directing users to `install` and `prompt`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b074f02970832e92905d9a979eecb6